### PR TITLE
Parameterise the port advertisement and port assignment

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -3,9 +3,11 @@ var mdns = require('mdns');
 var express = require('express');
 var app = express();
 
-// advertise a http server on port 4321
-var ad = mdns.createAdvertisement(mdns.tcp('http'), 4321, {
-  name: 'wilson'
+var port = Number(process.env.PORT) || 80;
+
+// advertise a http server on the specified port
+var ad = mdns.createAdvertisement(mdns.tcp('http'), port, {
+  name: 'calculator'
 });
 
 ad.start();
@@ -15,6 +17,6 @@ app.get('/', function (req, res) {
   res.send('Hello World!');
 });
 
-app.listen(80, function () {
-  console.log('Example app listening on port 80!');
+app.listen(port, function () {
+  console.log('Example app listening on port ' + port + '!');
 });

--- a/hub/index.js
+++ b/hub/index.js
@@ -5,7 +5,9 @@ var scanner = require('./lib/scanner')();
 var server = require('http').Server(app);
 var io = require('socket.io')(server);
 
-server.listen(80);
+var port = process.env.PORT || 80;
+
+server.listen(port);
 
 //
 app.use(express.static('client'));

--- a/hub/lib/scanner.js
+++ b/hub/lib/scanner.js
@@ -46,13 +46,14 @@ Scanner.prototype.get = function() {
 
 Scanner.prototype.onFound = function(service) {
   debug('found', service);
-  this.getManifest(service.host)
+  var serviceURL = `http://${service.host}:${service.port}`;
+  this.getManifest(serviceURL)
     .then(manifest => {
       if (!manifest) return;
       debug('got maniest', manifest);
 
       var app = this.cache[service.name] = {
-        base: `http://${service.host}`,
+        base: serviceURL,
         manifest: manifest
       };
 
@@ -68,9 +69,9 @@ Scanner.prototype.onLost = function(service) {
   this.emit('lost', match);
 };
 
-Scanner.prototype.getManifest = function(host) {
-  debug('get manifest', host);
-  return this.getManifestUrl(host)
+Scanner.prototype.getManifest = function(serviceURL) {
+  debug('get manifest', serviceURL);
+  return this.getManifestUrl(serviceURL)
     .then(url => {
       debug('got manifest url', url);
       return new Promise((resolve, reject) => {
@@ -82,17 +83,16 @@ Scanner.prototype.getManifest = function(host) {
     });
 };
 
-Scanner.prototype.getManifestUrl = function(host) {
+Scanner.prototype.getManifestUrl = function(serviceURL) {
   return new Promise((resolve, reject) => {
-    debug('get manifest url', host);
-    if (!host) return reject();
-    var index = `http://${host}`;
-    jsdom.env(index, [], function(err, win) {
+    debug('get manifest url', serviceURL);
+    if (!serviceURL) return reject();
+    jsdom.env(serviceURL, [], function(err, win) {
       if (err) return reject(err);
       var document = win.document;
       var manifest = document.querySelector('link[rel=manifest]');
       if (!manifest) return reject();
-      var location = url.resolve(index, manifest.href);
+      var location = url.resolve(serviceURL, manifest.href);
       resolve(location);
     });
   });


### PR DESCRIPTION
- Makes the service port parameterisable via the environment variable `PORT` (so you don't need to run as root)
- Advertises the Service's port which the hub uses to connect to along with the host name.
